### PR TITLE
Fix vault route datetime imports

### DIFF
--- a/backend/routes/vault.py
+++ b/backend/routes/vault.py
@@ -1,7 +1,7 @@
 # In /backend/routes/vault.py
 
 import os
-import time
+from datetime import datetime, timezone
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, validator
 from typing import Dict, Any


### PR DESCRIPTION
### Motivation
- The vault route writes a `last_synced` timestamp but the `datetime`/`timezone` symbols were not imported, causing a runtime error when syncing on-chain data to Supabase.

### Description
- Add `from datetime import datetime, timezone` and remove the unused `time` import in `backend/routes/vault.py` so `last_synced` is computed correctly with `datetime.now(timezone.utc)`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985e650843c8320ad42378f740417fe)