### PR TITLE
Improve vault UX cues and mobile navigation

### DIFF
--- a/frontend/components/Sidebar.tsx
+++ b/frontend/components/Sidebar.tsx
@@ -39,7 +39,27 @@ const Sidebar: React.FC<SidebarProps> = ({ activeTab, setActiveTab, account, isS
   ] as const;
 
   return (
-    <aside className="hidden lg:flex flex-col w-64 glass-morphism border-r border-white/5 p-6 h-screen relative z-30">
+    <>
+      <div className="lg:hidden sticky top-0 z-40 bg-[#020617]/95 backdrop-blur border-b border-white/10 px-3 py-3">
+        <div className="grid grid-cols-4 gap-2">
+          {navItems.map((item) => (
+            <button
+              key={`mobile-${item.id}`}
+              onClick={() => setActiveTab(item.id)}
+              className={`flex flex-col items-center justify-center gap-1 rounded-xl py-2 border transition-all ${
+                activeTab === item.id
+                  ? 'bg-indigo-600/15 text-white border-indigo-500/30'
+                  : 'bg-white/5 text-slate-400 border-white/10'
+              }`}
+            >
+              <span className={activeTab === item.id ? 'text-indigo-400' : 'text-slate-500'}>{item.icon}</span>
+              <span className="text-[9px] font-black uppercase tracking-wide">{item.label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <aside className="hidden lg:flex flex-col w-64 glass-morphism border-r border-white/5 p-6 h-screen relative z-30">
       <button 
         onClick={onGoHome}
         className="mb-12 px-2 flex items-center gap-3 group hover:opacity-80 transition-opacity text-left"
@@ -91,6 +111,7 @@ const Sidebar: React.FC<SidebarProps> = ({ activeTab, setActiveTab, account, isS
         )}
       </div>
     </aside>
+    </>
   );
 };
 

--- a/frontend/components/VaultManager.tsx
+++ b/frontend/components/VaultManager.tsx
@@ -27,6 +27,12 @@ const VaultManager: React.FC<VaultManagerProps> = ({ positions, prices, balances
   const currentPos = positions.find(p => p.collateralType === selectedAsset);
   const price = prices[selectedAsset];
 
+  useEffect(() => {
+    if (txStatus !== 'confirmed' && txStatus !== 'failed') return;
+    const timeout = window.setTimeout(() => setTxStatus('idle'), 5000);
+    return () => window.clearTimeout(timeout);
+  }, [txStatus]);
+
   const handleTransaction = async () => {
     if (!account || txStatus === 'pending' || txStatus === 'approving') return;
     
@@ -210,16 +216,22 @@ const VaultManager: React.FC<VaultManagerProps> = ({ positions, prices, balances
             </div>
 
             <div className="space-y-4">
-              <div className="flex justify-between text-[10px] font-black uppercase tracking-widest text-slate-500 px-1">
+              <div className="flex justify-between items-center text-[10px] font-black uppercase tracking-widest text-slate-500 px-1">
                 <span>Transaction Value</span>
-                <span className="font-mono text-indigo-400">{action === 'withdraw' ? `Max: ${currentPos?.depositedAmount.toFixed(4)}` : action === 'burn' ? `Max: ${currentPos?.mintedDebt.toFixed(2)}` : `Bal: ${balances[selectedAsset].toFixed(4)}`}</span>
+                <span className="font-mono text-indigo-300 text-[11px] tracking-normal">
+                  {action === 'withdraw'
+                    ? `Max Withdrawal: ${currentPos?.depositedAmount.toFixed(4) || '0.0000'} ${selectedAsset}`
+                    : action === 'burn'
+                      ? `Max Burn: ${currentPos?.mintedDebt.toFixed(2) || '0.00'} tGHSX`
+                      : `Your Balance: ${balances[selectedAsset].toFixed(4)} ${selectedAsset}`}
+                </span>
               </div>
               <div className="relative group">
                 <input
                   type="number"
                   value={action === 'burn' || action === 'mint' ? mintAmount : amount}
                   onChange={(e) => action === 'burn' || action === 'mint' ? setMintAmount(e.target.value) : setAmount(e.target.value)}
-                  placeholder="0.0000"
+                  placeholder={action === 'burn' || action === 'mint' ? '0.0 tGHSX' : `0.0 ${selectedAsset}`}
                   className="w-full bg-slate-950 border border-white/10 rounded-3xl px-8 py-7 text-3xl font-mono text-white focus:outline-none focus:ring-2 focus:ring-indigo-500/50 transition-all placeholder:text-slate-800"
                 />
                 <div className="absolute right-8 top-1/2 -translate-y-1/2 flex items-center gap-4">
@@ -259,6 +271,13 @@ const VaultManager: React.FC<VaultManagerProps> = ({ positions, prices, balances
                    </div>
                 </div>
                 <div className="flex-1 min-w-0">
+                  <button
+                    onClick={() => setTxStatus('idle')}
+                    className="float-right -mt-1 text-xs text-current/80 hover:text-white font-black"
+                    aria-label="Close status message"
+                  >
+                    ✕
+                  </button>
                   <h5 className="text-[11px] font-black uppercase tracking-[0.2em] leading-none mb-2">
                     {txStatus === 'confirmed' ? 'PROTOCOL COMMITMENT VERIFIED' : 'TRANSACTION REJECTED'}
                   </h5>


### PR DESCRIPTION
### Motivation
- Improve transaction input clarity and balance visibility in the Vault UI to reduce user confusion around amounts and assets. 
- Make status messages easier to dismiss and more accessible by providing both auto-dismiss and an explicit close control. 
- Ensure the app is navigable on small screens by adding a compact mobile navigation while preserving the desktop sidebar.

### Description
- Updated `frontend/components/VaultManager.tsx` to use asset-aware placeholders (`0.0 <asset>` / `0.0 tGHSX`), make the balance label explicit (`Your Balance: …`, `Max Withdrawal: …`), and surface those values more prominently. 
- Added an auto-dismiss `useEffect` which clears success/failure `txStatus` after 5 seconds and added a close (`✕`) button on the transaction status card for manual dismissal. 
- Updated `frontend/components/Sidebar.tsx` to add a `lg:hidden` mobile nav bar at the top that renders the same tabs in a compact grid for small screens. 
- Minor styling and accessibility tweaks around status controls and transaction header layout to improve readability across breakpoints.

### Testing
- Ran a production build with `npm --prefix frontend run build` which completed successfully. 
- Launched the dev server with `npm --prefix frontend run dev` and ran automated Playwright scripts to capture mobile and desktop screenshots, producing visual artifacts for verification. 
- Verified the app served and screenshots were generated without runtime build errors (visual smoke tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991895889e8832088c4dc22ac27b4a0)