### PR TITLE
Add native vault deposit/withdraw support and wire frontend flow

### DIFF
--- a/frontend/components/VaultManager.tsx
+++ b/frontend/components/VaultManager.tsx
@@ -31,7 +31,7 @@ const VaultManager: React.FC<VaultManagerProps> = ({ positions, prices, balances
     if (!Number.isFinite(val) || val <= 0) return "Transaction amount must be positive.";
 
     if (operation === 'deposit' && val > balances[selectedAsset]) {
-      return `Insufficient ${selectedAsset} wallet balance for this deposit.`;
+      return `Insufficient ${selectedAsset === CollateralType.WETH ? 'POL' : selectedAsset} wallet balance for this deposit.`;
     }
 
     if (operation === 'withdraw' && val > (currentPos?.depositedAmount || 0)) {
@@ -92,7 +92,7 @@ const VaultManager: React.FC<VaultManagerProps> = ({ positions, prices, balances
         return;
       }
 
-      if (action === 'deposit' || action === 'burn') {
+      if ((action === 'deposit' && selectedAsset !== CollateralType.WETH) || action === 'burn') {
         setTxStatus('approving');
         const allowance = await contractService.getAllowance(account, selectedAsset, action === 'burn');
         const required = ethers.parseUnits(val.toString(), action === 'burn' ? SYSTEM_PARAMS.TGHSX_DECIMALS : 18);
@@ -273,7 +273,7 @@ const VaultManager: React.FC<VaultManagerProps> = ({ positions, prices, balances
                 />
                 <div className="absolute right-8 top-1/2 -translate-y-1/2 flex items-center gap-4">
                    <button onClick={handleMax} className="text-[10px] font-black uppercase bg-indigo-600/20 text-indigo-400 px-4 py-2 rounded-xl border border-indigo-500/20 hover:bg-indigo-600/30 transition-colors">MAX</button>
-                   <span className="text-xs font-black text-slate-700 uppercase tracking-widest">{action === 'burn' || action === 'mint' ? 'tGHSX' : selectedAsset}</span>
+                   <span className="text-xs font-black text-slate-700 uppercase tracking-widest">{action === 'burn' || action === 'mint' ? 'tGHSX' : (selectedAsset === CollateralType.WETH ? 'POL' : selectedAsset)}</span>
                 </div>
               </div>
             </div>

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -39,7 +39,7 @@ async function main() {
     // --- 2. DEPLOY COLLATERAL VAULT ---
     console.log("\n📄 2. Deploying CollateralVault...");
     const CollateralVault = await ethers.getContractFactory("CollateralVault");
-    const collateralVault = await CollateralVault.deploy(tghsxToken.address);
+    const collateralVault = await CollateralVault.deploy(tghsxToken.address, mockTokens.WMATIC);
     await collateralVault.deployTransaction.wait(AMOY_CONFIG.confirmations);
     console.log("✅ CollateralVault deployed to:", collateralVault.address);
 


### PR DESCRIPTION
### Motivation
- Allow users holding native chain token (POL/WETH) to deposit/withdraw directly to the vault without manually wrapping, improving UX and aligning front-end interactions with the vault.

### Description
- Contracts: added `IWrappedNative` interface, immutable `wrappedNativeToken` storage, `depositNativeCollateral()` and `withdrawNativeCollateral(uint256)` functions, a `receive()` fallback, and `NativeTransferFailed` error to `contracts/CollateralVault.sol` so the vault can wrap/unwrap native token safely.
- Frontend service: extended `frontend/services/contractService.ts` ABI signatures and methods to call `depositNativeCollateral`/`withdrawNativeCollateral`, read native wallet balance for the WETH path, and handle token decimals per asset.
- Frontend UI: updated `frontend/components/VaultManager.tsx` to skip ERC20 approval for native deposits, show `POL` label when operating on native WETH flow, and adjust validation/labels accordingly.
- Deployment: updated `scripts/deploy.js` to pass the wrapped-native mock token into the `CollateralVault` constructor.
- Files changed: `contracts/CollateralVault.sol`, `frontend/services/contractService.ts`, `frontend/components/VaultManager.tsx`, `scripts/deploy.js`.

### Testing
- Ran `npm run build` in `frontend` and the production build completed successfully (passed).
- Attempted `npx hardhat compile` but compilation was blocked by the environment downloading the Solidity compiler (Hardhat error `HH502`), so on-chain compile/unit test steps could not run in this environment (blocked).
- Attempted `npx hardhat run scripts/deploy.js --network amoy` but deployment was also blocked for the same compiler/proxy download error (blocked).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991a61992f88320a67a27e6f7129b62)