### PR TITLE
Fix collateral deposit function name mismatch

### DIFF
--- a/frontend/services/contractService.ts
+++ b/frontend/services/contractService.ts
@@ -135,7 +135,7 @@ export class ContractService {
     const parsedAmount = ethers.parseUnits(amount.toString(), decimals);
     await (await tokenContract.approve(vaultAddress, parsedAmount)).wait();
 
-    const tx = await vault.depositERC20Collateral(tokenAddress, parsedAmount);
+    const tx = await vault.depositCollateral(tokenAddress, parsedAmount);
     return await tx.wait();
   }
 

--- a/frontend/src/abis/CollateralVault-ABI.json
+++ b/frontend/src/abis/CollateralVault-ABI.json
@@ -13,9 +13,9 @@
   },
   {
     "type": "function",
-    "name": "depositERC20Collateral",
+    "name": "depositCollateral",
     "inputs": [
-      {"name": "token", "type": "address"},
+      {"name": "collateral", "type": "address"},
       {"name": "amount", "type": "uint256"}
     ],
     "outputs": [],


### PR DESCRIPTION
### Motivation
- Fix a mismatch where the frontend called `depositERC20Collateral` but the deployed vault exposes `depositCollateral`, which caused MetaMask gas estimation to fail.

### Description
- Updated `frontend/src/abis/CollateralVault-ABI.json` to rename the ABI entry from `depositERC20Collateral` to `depositCollateral` and change the input name from `token` to `collateral`, and updated `frontend/services/contractService.ts` to call `vault.depositCollateral(tokenAddress, parsedAmount)`.

### Testing
- Verified the update by checking the two-file diff with `git diff` and inspecting the file contents with `nl`/`sed`, which show both the ABI and the service call now reference `depositCollateral`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992cc6f076483209acb6785b6463639)